### PR TITLE
Add PoW-PoS on-chain voting page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,43 +36,52 @@ const LinkForwarder = forwardRef(({ children, ...props }, ref) => {
 // News Banner Component
 function NewsBanner() {
   return (
-    <Box
-      sx={{
-        background: 'linear-gradient(90deg, #0059ff 0%, #00d9ff 50%, #0059ff 100%)',
-        backgroundSize: '200% 100%',
-        animation: 'gradientShift 3s ease infinite',
-        '@keyframes gradientShift': {
-          '0%': { backgroundPosition: '0% 50%' },
-          '50%': { backgroundPosition: '100% 50%' },
-          '100%': { backgroundPosition: '0% 50%' }
-        },
-        color: 'white',
-        padding: '12px 16px',
-        textAlign: 'center',
-        position: 'fixed',
-        top: 68,
-        left: 0,
-        right: 0,
-        zIndex: 1099,
-        boxShadow: '0 2px 8px rgba(0, 89, 255, 0.4)'
-      }}
+    <Link
+      to="/pow-pos-on-chain-voting"
+      style={{ textDecoration: 'none' }}
     >
-      <Typography
+      <Box
         sx={{
-          fontFamily: 'Roboto Mono',
-          fontWeight: 'bold',
-          fontSize: { xs: '0.75rem', sm: '0.9rem', md: '1rem' },
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: 1
+          background: 'linear-gradient(90deg, #0059ff 0%, #00d9ff 50%, #0059ff 100%)',
+          backgroundSize: '200% 100%',
+          animation: 'gradientShift 3s ease infinite',
+          '@keyframes gradientShift': {
+            '0%': { backgroundPosition: '0% 50%' },
+            '50%': { backgroundPosition: '100% 50%' },
+            '100%': { backgroundPosition: '0% 50%' }
+          },
+          color: 'white',
+          padding: '12px 16px',
+          textAlign: 'center',
+          position: 'fixed',
+          top: 68,
+          left: 0,
+          right: 0,
+          zIndex: 1099,
+          boxShadow: '0 2px 8px rgba(0, 89, 255, 0.4)',
+          cursor: 'pointer',
+          '&:hover': {
+            filter: 'brightness(1.1)'
+          }
         }}
       >
-        <NewReleasesIcon sx={{ fontSize: { xs: '1rem', sm: '1.25rem' } }} />
-        BREAKING NEWS: Mochimo Development Team Releases Alpha Version of Mobile Wallet for iOS Devices
-        <NewReleasesIcon sx={{ fontSize: { xs: '1rem', sm: '1.25rem' } }} />
-      </Typography>
-    </Box>
+        <Typography
+          sx={{
+            fontFamily: 'Roboto Mono',
+            fontWeight: 'bold',
+            fontSize: { xs: '0.75rem', sm: '0.9rem', md: '1rem' },
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 1
+          }}
+        >
+          <NewReleasesIcon sx={{ fontSize: { xs: '1rem', sm: '1.25rem' } }} />
+          VOTING IS NOW OPEN: Does MCM Become Proof-of-Stake? Click Here for Instructions
+          <NewReleasesIcon sx={{ fontSize: { xs: '1rem', sm: '1.25rem' } }} />
+        </Typography>
+      </Box>
+    </Link>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -37,7 +37,7 @@ const LinkForwarder = forwardRef(({ children, ...props }, ref) => {
 function NewsBanner() {
   return (
     <Link
-      to="/pow-pos-on-chain-voting"
+      to="/vote"
       style={{ textDecoration: 'none' }}
     >
       <Box
@@ -254,7 +254,7 @@ export default function App () {
               </Route>
               <Route path='mining' element={<Mining />} />
               <Route path='faq' element={<FAQ />} />
-              <Route path='pow-pos-on-chain-voting' element={<Vote />} />
+              <Route path='vote' element={<Vote />} />
             </Routes>
           </Box>
           <Routes>

--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ import ExplorerLedger from 'app/explorer-ledger';
 import Footer from 'app/component/Footer';
 import Mining from './app/pages/Mining';
 import FAQ from './app/pages/FAQ';
+import Vote from './app/pages/Vote';
 
 const BackgroundWave = lazy(() => import('app/component/BackgroundWave'));
 
@@ -244,6 +245,7 @@ export default function App () {
               </Route>
               <Route path='mining' element={<Mining />} />
               <Route path='faq' element={<FAQ />} />
+              <Route path='pow-pos-on-chain-voting' element={<Vote />} />
             </Routes>
           </Box>
           <Routes>

--- a/src/app/pages/Vote.js
+++ b/src/app/pages/Vote.js
@@ -1,0 +1,98 @@
+import { useEffect } from 'react';
+import { Box, Container, Paper, Typography } from '@mui/material';
+import { scrollToTopNow } from '../component/ScrollToTop';
+
+export default function Vote() {
+  useEffect(() => scrollToTopNow(), []);
+
+  return (
+    <Container maxWidth="md">
+      <Typography variant='h2' align='center' gutterBottom sx={{ marginTop: 4, marginBottom: 4 }}>
+        PoW-PoS On-Chain Voting
+      </Typography>
+      
+      <Paper
+        elevation={3}
+        sx={{
+          padding: 4,
+          backgroundColor: 'rgba(30, 30, 30, 0.85)',
+          borderRadius: 2
+        }}
+      >
+        <Typography variant="body1" paragraph>
+          After a lot of community discussion over the years, the Core Contributor Team is asking for your help in choosing the future of the Mochimo network's consensus algorithm.
+        </Typography>
+
+        <Typography variant="body1" paragraph>
+          To do this we will be holding an on-chain vote that all holders can participate in.
+        </Typography>
+
+        <Typography variant="h5" gutterBottom sx={{ mt: 3 }}>
+          The Question
+        </Typography>
+        <Typography variant="body1" paragraph>
+          Do you want the Mochimo network to remain <strong>PoW</strong> (Proof of Work, mined by GPU miners) or do you want Mochimo to migrate to a <strong>PoS</strong> (Proof of Stake, where validator nodes confirm transactions and individual holders can stake their coins for staking rewards)?
+        </Typography>
+
+        <Typography variant="h5" gutterBottom sx={{ mt: 3 }}>
+          How to Vote
+        </Typography>
+        <Typography variant="body1" paragraph>
+          In order to answer this question, each person who desires to vote must send a single transaction to the official MCM voting address:
+        </Typography>
+
+        <Box
+          sx={{
+            backgroundColor: 'rgba(0, 89, 255, 0.15)',
+            border: '1px solid #0059ff',
+            borderRadius: 1,
+            padding: 2,
+            textAlign: 'center',
+            my: 2
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{
+              fontFamily: 'Roboto Mono',
+              wordBreak: 'break-all'
+            }}
+          >
+            c2QVMZKC1KyQq84VVQc32sniKQhB6e
+          </Typography>
+        </Box>
+
+        <Typography variant="body1" paragraph>
+          <strong>Before the end of April 2026.</strong>
+        </Typography>
+
+        <Typography variant="body1" paragraph>
+          Send the smallest amount the network will accept which is <strong>0.000000501 MCM</strong>, and add a memo field with either the word <strong>POW</strong> or <strong>POS</strong> in it.
+        </Typography>
+
+        <Typography variant="body1" paragraph>
+          The memo represents the network type you want to have in the future. If you want to migrate to PoS for example, enter <strong>POS</strong> in the memo field.
+        </Typography>
+
+        <Typography variant="h5" gutterBottom sx={{ mt: 3 }}>
+          Voting Rules
+        </Typography>
+        <Typography variant="body1" component="div">
+          <ul>
+            <li>Only the first vote transaction received from each address with a proper memo string included (either "POW" or "POS") will count.</li>
+            <li>Please don't vote multiple times.</li>
+            <li>To prevent any coin shuffling double-voting shenanigans, on May 1st we will check each address with either a POW or POS vote transaction.</li>
+            <li>Whatever that address balance shows on May 1st is how many votes will be credited to either PoS or PoW.</li>
+          </ul>
+        </Typography>
+
+        <Typography variant="h5" gutterBottom sx={{ mt: 3 }}>
+          Results
+        </Typography>
+        <Typography variant="body1" paragraph>
+          Vote results will be tabulated and presented on this page late on May 1st.
+        </Typography>
+      </Paper>
+    </Container>
+  );
+}

--- a/src/app/pages/Vote.js
+++ b/src/app/pages/Vote.js
@@ -7,7 +7,37 @@ export default function Vote() {
 
   return (
     <Container maxWidth="md">
-      <Typography variant='h2' align='center' gutterBottom sx={{ marginTop: 4, marginBottom: 4 }}>
+      <Box
+        sx={{
+          background: 'linear-gradient(90deg, #00c853 0%, #00e676 50%, #00c853 100%)',
+          backgroundSize: '200% 100%',
+          animation: 'gradientShift 3s ease infinite',
+          '@keyframes gradientShift': {
+            '0%': { backgroundPosition: '0% 50%' },
+            '50%': { backgroundPosition: '100% 50%' },
+            '100%': { backgroundPosition: '0% 50%' }
+          },
+          color: 'white',
+          padding: 2,
+          borderRadius: 2,
+          textAlign: 'center',
+          marginTop: 4,
+          marginBottom: 3,
+          boxShadow: '0 4px 12px rgba(0, 200, 83, 0.4)'
+        }}
+      >
+        <Typography
+          variant="h4"
+          sx={{
+            fontFamily: 'Roboto Mono',
+            fontWeight: 'bold'
+          }}
+        >
+          VOTING IS NOW OPEN
+        </Typography>
+      </Box>
+
+      <Typography variant='h2' align='center' gutterBottom sx={{ marginBottom: 4 }}>
         PoW-PoS On-Chain Voting
       </Typography>
       
@@ -62,9 +92,20 @@ export default function Vote() {
           </Typography>
         </Box>
 
-        <Typography variant="body1" paragraph>
-          <strong>Before the end of April 2026.</strong>
-        </Typography>
+        <Box
+          sx={{
+            backgroundColor: 'rgba(255, 152, 0, 0.15)',
+            border: '1px solid #ff9800',
+            borderRadius: 1,
+            padding: 2,
+            textAlign: 'center',
+            my: 2
+          }}
+        >
+          <Typography variant="h6" sx={{ fontFamily: 'Roboto Mono', color: '#ff9800' }}>
+            Voting closes: 23:59:59 UTC on April 30th, 2026
+          </Typography>
+        </Box>
 
         <Typography variant="body1" paragraph>
           Send the smallest amount the network will accept which is <strong>0.000000501 MCM</strong>, and add a memo field with either the word <strong>POW</strong> or <strong>POS</strong> in it.


### PR DESCRIPTION
## Summary
Adds a new voting page for the PoW vs PoS community vote.

## Changes
- Create Vote.js component with voting instructions
- Add /pow-pos-on-chain-voting route

## Details
The page includes:
- Voting address: c2QVMZKC1KyQq84VVQc32sniKQhB6e
- Instructions for voting (send 0.000000501 MCM with POW or POS memo)
- Voting rules (first vote counts, balance snapshot on May 1st)
- Timeline for May 1st results tabulation